### PR TITLE
Feature/collection ad

### DIFF
--- a/app/src/main/java/com/wojdor/memolki/data/local/user/UserLocalDataSource.kt
+++ b/app/src/main/java/com/wojdor/memolki/data/local/user/UserLocalDataSource.kt
@@ -56,10 +56,22 @@ class UserLocalDataSource @Inject constructor(
         }
     }
 
+    val encryptedUnlockedCardPairsFromAdsCount: Flow<String?> =
+        dataRead.map { it[Key.UNLOCKED_CARD_PAIRS_FROM_ADS_COUNT] }
+
+    suspend fun setEncryptedUnlockedCardPairsFromAdsCount(transform: (encryptedValue: String?) -> String) {
+        dataWrite.edit { prefs ->
+            prefs[Key.UNLOCKED_CARD_PAIRS_FROM_ADS_COUNT] =
+                transform(prefs[Key.UNLOCKED_CARD_PAIRS_FROM_ADS_COUNT])
+        }
+    }
+
     private object Key {
         val COINS = stringPreferencesKey("coins")
         val TOTAL_COINS = stringPreferencesKey("total_coins")
         val TOTAL_MATCHED_CARD_PAIR_COUNT = stringPreferencesKey("total_matched_card_pair_count")
         val TOTAL_GAMES_PLAYED = stringPreferencesKey("total_games_played")
+        val UNLOCKED_CARD_PAIRS_FROM_ADS_COUNT =
+            stringPreferencesKey("unlocked_card_pairs_from_ads_count")
     }
 }

--- a/app/src/main/java/com/wojdor/memolki/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/wojdor/memolki/data/repository/UserRepository.kt
@@ -56,6 +56,16 @@ class UserRepository @Inject constructor(
         }
     }
 
+    fun getUnlockedCardPairsFromAdsCount() =
+        decryptLong(userLocalDataSource.encryptedUnlockedCardPairsFromAdsCount)
+
+    suspend fun incrementUnlockedCardPairsFromAdsCount() {
+        userLocalDataSource.setEncryptedUnlockedCardPairsFromAdsCount { encryptedCount ->
+            val count = decryptLong(encryptedCount)
+            encryptor.encrypt(count + 1)
+        }
+    }
+
     private fun decryptLong(encryptedValue: String?): Long {
         return if (encryptedValue.isNullOrEmpty()) {
             DEFAULT_LONG_VALUE

--- a/app/src/main/java/com/wojdor/memolki/domain/usecase/GetUnlockedCardPairsFromAdsCountUseCase.kt
+++ b/app/src/main/java/com/wojdor/memolki/domain/usecase/GetUnlockedCardPairsFromAdsCountUseCase.kt
@@ -1,0 +1,17 @@
+package com.wojdor.memolki.domain.usecase
+
+import com.wojdor.memolki.data.repository.UserRepository
+import com.wojdor.memolki.di.coroutine.IoDispatcher
+import com.wojdor.memolki.domain.usecase.base.BaseUseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class GetUnlockedCardPairsFromAdsCountUseCase @Inject constructor(
+    @IoDispatcher coroutineDispatcher: CoroutineDispatcher,
+    private val userRepository: UserRepository
+) : BaseUseCase<Long>(coroutineDispatcher) {
+
+    override fun execute() =
+        userRepository.getUnlockedCardPairsFromAdsCount().map { Result.success(it) }
+}

--- a/app/src/main/java/com/wojdor/memolki/domain/usecase/IncrementUnlockedCardPairsFromAdsCountUseCase.kt
+++ b/app/src/main/java/com/wojdor/memolki/domain/usecase/IncrementUnlockedCardPairsFromAdsCountUseCase.kt
@@ -1,0 +1,19 @@
+package com.wojdor.memolki.domain.usecase
+
+import com.wojdor.memolki.data.repository.UserRepository
+import com.wojdor.memolki.di.coroutine.IoDispatcher
+import com.wojdor.memolki.domain.usecase.base.BaseUseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class IncrementUnlockedCardPairsFromAdsCountUseCase @Inject constructor(
+    @IoDispatcher coroutineDispatcher: CoroutineDispatcher,
+    private val userRepository: UserRepository
+) : BaseUseCase<Unit>(coroutineDispatcher) {
+
+    override fun execute() = flow {
+        userRepository.incrementUnlockedCardPairsFromAdsCount()
+        emit(Result.success(Unit))
+    }
+}

--- a/app/src/main/java/com/wojdor/memolki/domain/usecase/RewardCoinsForShopAdUseCase.kt
+++ b/app/src/main/java/com/wojdor/memolki/domain/usecase/RewardCoinsForShopAdUseCase.kt
@@ -4,6 +4,7 @@ import com.wojdor.memolki.data.repository.UserRepository
 import com.wojdor.memolki.di.coroutine.IoDispatcher
 import com.wojdor.memolki.domain.usecase.base.BaseUseCase
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
@@ -19,8 +20,11 @@ class RewardCoinsForShopAdUseCase @Inject constructor(
         emit(Result.success(Unit))
     }
 
-    private fun calculateRewardedCoins(): Long {
-        // TODO: Use getLevelsUseCase
-        return 10
+    private suspend fun calculateRewardedCoins(): Long {
+        val unlockedLevels = getLevelsUseCase().first().getOrNull() ?: return 0
+        val biggestUnlockedLevel = unlockedLevels.filter { it.isUnlocked }.maxByOrNull { it.id }
+        return biggestUnlockedLevel?.let {
+            it.columns * it.rows.toLong()
+        } ?: 0
     }
 }

--- a/app/src/main/java/com/wojdor/memolki/domain/usecase/RewardCoinsForShopAdUseCase.kt
+++ b/app/src/main/java/com/wojdor/memolki/domain/usecase/RewardCoinsForShopAdUseCase.kt
@@ -21,10 +21,14 @@ class RewardCoinsForShopAdUseCase @Inject constructor(
     }
 
     private suspend fun calculateRewardedCoins(): Long {
-        val unlockedLevels = getLevelsUseCase().first().getOrNull() ?: return 0
+        val unlockedLevels = getLevelsUseCase().first().getOrNull() ?: return DEFAULT_REWARDED_COINS
         val biggestUnlockedLevel = unlockedLevels.filter { it.isUnlocked }.maxByOrNull { it.id }
         return biggestUnlockedLevel?.let {
             it.columns * it.rows.toLong()
-        } ?: 0
+        } ?: DEFAULT_REWARDED_COINS
+    }
+
+    companion object {
+        private const val DEFAULT_REWARDED_COINS = 0L
     }
 }

--- a/app/src/main/java/com/wojdor/memolki/domain/usecase/RewardCoinsForShopAdUseCase.kt
+++ b/app/src/main/java/com/wojdor/memolki/domain/usecase/RewardCoinsForShopAdUseCase.kt
@@ -1,0 +1,26 @@
+package com.wojdor.memolki.domain.usecase
+
+import com.wojdor.memolki.data.repository.UserRepository
+import com.wojdor.memolki.di.coroutine.IoDispatcher
+import com.wojdor.memolki.domain.usecase.base.BaseUseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class RewardCoinsForShopAdUseCase @Inject constructor(
+    @IoDispatcher coroutineDispatcher: CoroutineDispatcher,
+    private val userRepository: UserRepository,
+    private val getLevelsUseCase: GetLevelsUseCase
+) : BaseUseCase<Unit>(coroutineDispatcher) {
+
+    override fun execute() = flow {
+        val rewardedCoins = calculateRewardedCoins()
+        userRepository.addCoins(rewardedCoins)
+        emit(Result.success(Unit))
+    }
+
+    private fun calculateRewardedCoins(): Long {
+        // TODO: Use getLevelsUseCase
+        return 10
+    }
+}

--- a/app/src/main/java/com/wojdor/memolki/domain/usecase/UnlockRandomCardIfEnoughCoinsUseCase.kt
+++ b/app/src/main/java/com/wojdor/memolki/domain/usecase/UnlockRandomCardIfEnoughCoinsUseCase.kt
@@ -1,6 +1,5 @@
 package com.wojdor.memolki.domain.usecase
 
-import com.wojdor.memolki.data.repository.CardRepository
 import com.wojdor.memolki.data.repository.UserRepository
 import com.wojdor.memolki.di.coroutine.IoDispatcher
 import com.wojdor.memolki.domain.usecase.base.BaseUseCase
@@ -13,29 +12,23 @@ import javax.inject.Inject
 class UnlockRandomCardIfEnoughCoinsUseCase @Inject constructor(
     @IoDispatcher coroutineDispatcher: CoroutineDispatcher,
     private val calculateNextCardPairCostUseCase: CalculateNextCardPairCostUseCase,
-    private val cardRepository: CardRepository,
+    private val unlockRandomCardUseCase: UnlockRandomCardUseCase,
     private val userRepository: UserRepository
 ) : BaseUseCase<Unit>(coroutineDispatcher) {
 
     override fun execute(): Flow<Result<Unit>> = flow {
-        val unlockedIds = cardRepository.getUnlockedCardPairs()
-            .map { it.first.pairId }
-            .toSet()
-        val notUnlockedCardPairs = cardRepository.getAllCardPairs()
-            .filter { it.first.pairId !in unlockedIds }
-        if (notUnlockedCardPairs.isEmpty()) {
-            emit(Result.failure(IllegalStateException("All card pairs are already unlocked")))
-            return@flow
-        }
         val nextCardPairCost = calculateNextCardPairCostUseCase().first().getOrThrow()
         val userCoins = userRepository.getCoins().first()
         if (userCoins < nextCardPairCost) {
             emit(Result.failure(IllegalStateException("Not enough coins to unlock a new card pair. User coins: $userCoins, next card pair cost: $nextCardPairCost")))
-            return@flow
+        } else {
+            unlockRandomCardUseCase().first()
+                .onSuccess {
+                    userRepository.removeCoins(nextCardPairCost.toLong())
+                    emit(Result.success(Unit))
+                }.onFailure {
+                    emit(Result.failure(it))
+                }
         }
-        userRepository.removeCoins(nextCardPairCost.toLong())
-        val randomCardPairToUnlock = notUnlockedCardPairs.random()
-        cardRepository.addUnlockedCardPairId(randomCardPairToUnlock.first.pairId)
-        emit(Result.success(Unit))
     }
 }

--- a/app/src/main/java/com/wojdor/memolki/domain/usecase/UnlockRandomCardUseCase.kt
+++ b/app/src/main/java/com/wojdor/memolki/domain/usecase/UnlockRandomCardUseCase.kt
@@ -1,0 +1,29 @@
+package com.wojdor.memolki.domain.usecase
+
+import com.wojdor.memolki.data.repository.CardRepository
+import com.wojdor.memolki.di.coroutine.IoDispatcher
+import com.wojdor.memolki.domain.usecase.base.BaseUseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class UnlockRandomCardUseCase @Inject constructor(
+    @IoDispatcher coroutineDispatcher: CoroutineDispatcher,
+    private val cardRepository: CardRepository
+) : BaseUseCase<Unit>(coroutineDispatcher) {
+
+    override fun execute() = flow {
+        val unlockedIds = cardRepository.getUnlockedCardPairs()
+            .map { it.first.pairId }
+            .toSet()
+        val notUnlockedCardPairs = cardRepository.getAllCardPairs()
+            .filter { it.first.pairId !in unlockedIds }
+        if (notUnlockedCardPairs.isEmpty()) {
+            emit(Result.failure(IllegalStateException("All card pairs are already unlocked")))
+        } else {
+            val randomCardPairToUnlock = notUnlockedCardPairs.random()
+            cardRepository.addUnlockedCardPairId(randomCardPairToUnlock.first.pairId)
+            emit(Result.success(Unit))
+        }
+    }
+}

--- a/app/src/main/java/com/wojdor/memolki/ui/component/AutoSizeText.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/component/AutoSizeText.kt
@@ -1,4 +1,4 @@
-package com.wojdor.memolki.ui.components
+package com.wojdor.memolki.ui.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size

--- a/app/src/main/java/com/wojdor/memolki/ui/component/BaseMenuItem.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/component/BaseMenuItem.kt
@@ -1,4 +1,4 @@
-package com.wojdor.memolki.ui.components
+package com.wojdor.memolki.ui.component
 
 import androidx.annotation.StringRes
 import androidx.compose.material3.Button

--- a/app/src/main/java/com/wojdor/memolki/ui/component/CoinsAmount.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/component/CoinsAmount.kt
@@ -1,4 +1,4 @@
-package com.wojdor.memolki.ui.components
+package com.wojdor.memolki.ui.component
 
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState

--- a/app/src/main/java/com/wojdor/memolki/ui/component/Flippable.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/component/Flippable.kt
@@ -1,4 +1,4 @@
-package com.wojdor.memolki.ui.components
+package com.wojdor.memolki.ui.component
 
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState

--- a/app/src/main/java/com/wojdor/memolki/ui/component/XmlDrawable.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/component/XmlDrawable.kt
@@ -1,4 +1,4 @@
-package com.wojdor.memolki.ui.components
+package com.wojdor.memolki.ui.component
 
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/cardpairdetails/component/CardPairDetailsContent.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/cardpairdetails/component/CardPairDetailsContent.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import com.wojdor.memolki.R
 import com.wojdor.memolki.domain.model.CardModel
 import com.wojdor.memolki.domain.model.CardPairModel
-import com.wojdor.memolki.ui.components.AutoSizeText
+import com.wojdor.memolki.ui.component.AutoSizeText
 import com.wojdor.memolki.ui.feature.game.component.FrontCardItem
 import com.wojdor.memolki.ui.theme.AppTheme
 

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/chooselevel/component/ChooseLevelItem.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/chooselevel/component/ChooseLevelItem.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wojdor.memolki.R
-import com.wojdor.memolki.ui.components.BaseMenuItem
+import com.wojdor.memolki.ui.component.BaseMenuItem
 import com.wojdor.memolki.ui.theme.AppTheme
 
 @Composable

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionCallbacks.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionCallbacks.kt
@@ -6,4 +6,5 @@ data class CollectionCallbacks(
     val onShopButtonClick: () -> Unit = {},
     val onUnlockedCardPairClick: (CollectionCardPairModel.Unlocked) -> Unit = {},
     val onUnlockWithCoinsClick: (CollectionCardPairModel.LockedToUnlockWithCoins) -> Unit = {},
+    val onUnlockWithAdClick: (CollectionCardPairModel.LockedToUnlockWithAd) -> Unit = {},
 )

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionEffect.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionEffect.kt
@@ -1,9 +1,11 @@
 package com.wojdor.memolki.ui.feature.collection
 
 import com.wojdor.memolki.domain.model.CardPairModel
+import com.wojdor.memolki.ui.ads.RewardedAd
 import com.wojdor.memolki.ui.base.UiEffect
 
 sealed class CollectionEffect : UiEffect {
     object OpenShopScreen : CollectionEffect()
     data class OpenCardPairDetailsScreen(val cardPairModel: CardPairModel) : CollectionEffect()
+    data class ShowAd(val rewardedAd: RewardedAd) : CollectionEffect()
 }

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionIntent.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionIntent.kt
@@ -14,4 +14,12 @@ sealed class CollectionIntent : UiIntent {
     data class OnUnlockWithCoinsClick(
         val collectionCardPairModel: CollectionCardPairModel.LockedToUnlockWithCoins
     ) : CollectionIntent()
+
+    data class OnUnlockWithAdClick(
+        val collectionCardPairModel: CollectionCardPairModel.LockedToUnlockWithAd
+    ) : CollectionIntent()
+
+    object OnAdReward : CollectionIntent()
+
+    data class OnAdDismiss(val wasRewardGranted: Boolean) : CollectionIntent()
 }

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionScreen.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionScreen.kt
@@ -1,5 +1,7 @@
 package com.wojdor.memolki.ui.feature.collection
 
+import android.app.Activity
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -10,6 +12,7 @@ import com.wojdor.memolki.R
 import com.wojdor.memolki.domain.model.CardModel
 import com.wojdor.memolki.domain.model.CardPairModel
 import com.wojdor.memolki.domain.model.CollectionCardPairModel
+import com.wojdor.memolki.ui.ads.RewardedAd
 import com.wojdor.memolki.ui.app.navigateToCardPairDetailsScreen
 import com.wojdor.memolki.ui.app.navigateToShop
 import com.wojdor.memolki.ui.base.CollectUiEffects
@@ -35,14 +38,17 @@ private fun HandleEffect(
     cardPairDetailsViewModel: CardPairDetailsViewModel,
     navController: NavController
 ) {
-    CollectUiEffects(viewModel) {
-        when (it) {
+    val activity = LocalActivity.current
+    CollectUiEffects(viewModel) { effect ->
+        when (effect) {
             is CollectionEffect.OpenShopScreen -> navController.navigateToShop()
             is CollectionEffect.OpenCardPairDetailsScreen -> openCardPairDetailsScreen(
                 cardPairDetailsViewModel,
                 navController,
-                it.cardPairModel
+                effect.cardPairModel
             )
+
+            is CollectionEffect.ShowAd -> activity?.let { showAd(it, viewModel, effect.rewardedAd) }
         }
     }
 }
@@ -54,7 +60,18 @@ private fun openCardPairDetailsScreen(
 ) {
     cardPairDetailsViewModel.sendIntent(CardPairDetailsIntent.OnCardPairDetailsShow(cardPairModel))
     navController.navigateToCardPairDetailsScreen()
+}
 
+private fun showAd(
+    activity: Activity,
+    viewModel: CollectionViewModel,
+    rewardedAd: RewardedAd
+) {
+    rewardedAd.show(
+        activity,
+        onGrantReward = { viewModel.sendIntent(CollectionIntent.OnAdReward) },
+        onAdDismiss = { viewModel.sendIntent(CollectionIntent.OnAdDismiss(it)) }
+    )
 }
 
 @Composable
@@ -71,6 +88,9 @@ private fun HandleState(
         },
         onUnlockWithCoinsClick = {
             viewModel.sendIntent(CollectionIntent.OnUnlockWithCoinsClick(it))
+        },
+        onUnlockWithAdClick = {
+            viewModel.sendIntent(CollectionIntent.OnUnlockWithAdClick(it))
         }
     )
     CollectionScreen(state, callbacks)
@@ -128,8 +148,8 @@ private fun getCollectionCardPairsForPreview() = listOf(
             CardModel.Text("strawberry_half", "strawberry", R.string.strawberry)
         )
     ),
-    CollectionCardPairModel.LockedToUnlockWithAd,
     CollectionCardPairModel.LockedToUnlockWithCoins(100),
+    CollectionCardPairModel.LockedToUnlockWithAd,
     CollectionCardPairModel.Locked,
     CollectionCardPairModel.Locked,
     CollectionCardPairModel.Locked,

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionViewModel.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionViewModel.kt
@@ -70,7 +70,7 @@ class CollectionViewModel @Inject constructor(
         if (wasRewardGranted) {
             rewardCardForAd()
         }
-        loadAd(wasRewardGranted)
+        loadCardPairsAndAd(wasRewardGranted)
     }
 
     private fun rewardCardForAd() {
@@ -81,12 +81,12 @@ class CollectionViewModel @Inject constructor(
         }.launchIn(viewModelScope)
     }
 
-    private fun loadAd(wasRewardGranted: Boolean = false) {
-        if (allRewardedAds.endGameCoinsAd.isLoaded && !wasRewardGranted) {
+    private fun loadCardPairsAndAd(wasRewardGranted: Boolean = false) {
+        if (allRewardedAds.collectionCardPairAd.isLoaded && !wasRewardGranted) {
             loadCardPairs(isAdAvailable = true)
         } else {
             loadCardPairs(isAdAvailable = false)
-            allRewardedAds.endGameCoinsAd.load(
+            allRewardedAds.collectionCardPairAd.load(
                 onLoaded = {
                     if (!wasRewardGranted) {
                         loadCardPairs(isAdAvailable = true)
@@ -100,9 +100,8 @@ class CollectionViewModel @Inject constructor(
     }
 
     private fun loadData(animateCoins: Boolean = false) {
-        loadAd()
+        loadCardPairsAndAd()
         loadCoins(animateCoins)
-        loadCardPairs(isAdAvailable = allRewardedAds.endGameCoinsAd.isLoaded)
     }
 
     private fun loadCoins(animateCoins: Boolean) {
@@ -233,7 +232,7 @@ class CollectionViewModel @Inject constructor(
 
     private fun onUnlockWithAdClick() {
         hapticFeedback.vibrateLow()
-        sendEffect(CollectionEffect.ShowAd(allRewardedAds.endGameCoinsAd))
+        sendEffect(CollectionEffect.ShowAd(allRewardedAds.collectionCardPairAd))
     }
 
     companion object {

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionViewModel.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionViewModel.kt
@@ -63,7 +63,6 @@ class CollectionViewModel @Inject constructor(
     private fun onAdReward() {
         loadCardPairs(isAdAvailable = false)
         incrementUnlockedCardPairsFromAdsCountUseCase().launchIn(viewModelScope)
-        allRewardedAds.collectionCardPairAd.load()
     }
 
     private fun onAdDismiss(wasRewardGranted: Boolean) {

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionViewModel.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionViewModel.kt
@@ -102,7 +102,7 @@ class CollectionViewModel @Inject constructor(
     private fun loadData(animateCoins: Boolean = false) {
         loadAd()
         loadCoins(animateCoins)
-        loadCardPairs(isAdAvailable = false)
+        loadCardPairs(isAdAvailable = allRewardedAds.endGameCoinsAd.isLoaded)
     }
 
     private fun loadCoins(animateCoins: Boolean) {

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionViewModel.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/CollectionViewModel.kt
@@ -7,10 +7,13 @@ import com.wojdor.memolki.domain.model.CollectionCardPairModel
 import com.wojdor.memolki.domain.usecase.CalculateNextCardPairCostUseCase
 import com.wojdor.memolki.domain.usecase.GetAllCardPairsCountUseCase
 import com.wojdor.memolki.domain.usecase.GetCoinsUseCase
+import com.wojdor.memolki.domain.usecase.GetUnlockedCardPairsFromAdsCountUseCase
 import com.wojdor.memolki.domain.usecase.GetUnlockedCardPairsUseCase
+import com.wojdor.memolki.domain.usecase.IncrementUnlockedCardPairsFromAdsCountUseCase
 import com.wojdor.memolki.domain.usecase.UnlockRandomCardIfEnoughCoinsUseCase
+import com.wojdor.memolki.domain.usecase.UnlockRandomCardUseCase
+import com.wojdor.memolki.ui.ads.AllRewardedAds
 import com.wojdor.memolki.ui.base.MviViewModel
-import com.wojdor.memolki.ui.feature.collection.CollectionViewModel.Companion.UNLOCK_WITH_COINS_COUNT
 import com.wojdor.memolki.util.media.CoinsPlayer
 import com.wojdor.memolki.util.media.HapticFeedback
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,11 +31,15 @@ class CollectionViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val coinsPlayer: CoinsPlayer,
     private val hapticFeedback: HapticFeedback,
+    private val allRewardedAds: AllRewardedAds,
     private val getCoinsUseCase: GetCoinsUseCase,
     private val getUnlockedCardPairs: GetUnlockedCardPairsUseCase,
     private val getAllCardPairsCountUseCase: GetAllCardPairsCountUseCase,
     private val calculateNextCardPairCostUseCase: CalculateNextCardPairCostUseCase,
-    private val unlockRandomCardIfEnoughCoinsUseCase: UnlockRandomCardIfEnoughCoinsUseCase
+    private val unlockRandomCardIfEnoughCoinsUseCase: UnlockRandomCardIfEnoughCoinsUseCase,
+    private val unlockRandomCardUseCase: UnlockRandomCardUseCase,
+    private val getUnlockedCardPairsFromAdsCountUseCase: GetUnlockedCardPairsFromAdsCountUseCase,
+    private val incrementUnlockedCardPairsFromAdsCountUseCase: IncrementUnlockedCardPairsFromAdsCountUseCase
 ) : MviViewModel<CollectionIntent, CollectionState>(
     savedStateHandle,
     CollectionState()
@@ -44,15 +51,58 @@ class CollectionViewModel @Inject constructor(
 
     override fun onIntent(intent: CollectionIntent) {
         when (intent) {
-            is CollectionIntent.OnShopClick -> onShopClick()
+            CollectionIntent.OnShopClick -> onShopClick()
             is CollectionIntent.OnCardPairClick -> onCardPairClick(intent)
             is CollectionIntent.OnUnlockWithCoinsClick -> onUnlockWithCoinsClick()
+            is CollectionIntent.OnUnlockWithAdClick -> onUnlockWithAdClick()
+            CollectionIntent.OnAdReward -> onAdReward()
+            is CollectionIntent.OnAdDismiss -> onAdDismiss(intent.wasRewardGranted)
+        }
+    }
+
+    private fun onAdReward() {
+        loadCardPairs(isAdAvailable = false)
+        incrementUnlockedCardPairsFromAdsCountUseCase().launchIn(viewModelScope)
+        allRewardedAds.collectionCardPairAd.load()
+    }
+
+    private fun onAdDismiss(wasRewardGranted: Boolean) {
+        if (wasRewardGranted) {
+            rewardCardForAd()
+        }
+        loadAd(wasRewardGranted)
+    }
+
+    private fun rewardCardForAd() {
+        unlockRandomCardUseCase().onEach { result ->
+            result.onSuccess {
+                loadData()
+            }
+        }.launchIn(viewModelScope)
+    }
+
+    private fun loadAd(wasRewardGranted: Boolean = false) {
+        if (allRewardedAds.endGameCoinsAd.isLoaded && !wasRewardGranted) {
+            loadCardPairs(isAdAvailable = true)
+        } else {
+            loadCardPairs(isAdAvailable = false)
+            allRewardedAds.endGameCoinsAd.load(
+                onLoaded = {
+                    if (!wasRewardGranted) {
+                        loadCardPairs(isAdAvailable = true)
+                    }
+                },
+                onFailed = {
+                    loadCardPairs(isAdAvailable = false)
+                }
+            )
         }
     }
 
     private fun loadData(animateCoins: Boolean = false) {
+        loadAd()
         loadCoins(animateCoins)
-        loadCardPairs()
+        loadCardPairs(isAdAvailable = false)
     }
 
     private fun loadCoins(animateCoins: Boolean) {
@@ -63,7 +113,7 @@ class CollectionViewModel @Inject constructor(
         }.launchIn(viewModelScope)
     }
 
-    private fun loadCardPairs() {
+    private fun loadCardPairs(isAdAvailable: Boolean) {
         combine(
             getUnlockedCardPairs()
                 .map { it.getOrNull() }
@@ -73,20 +123,25 @@ class CollectionViewModel @Inject constructor(
                 .filterNotNull(),
             calculateNextCardPairCostUseCase()
                 .map { it.getOrNull() }
+                .filterNotNull(),
+            getUnlockedCardPairsFromAdsCountUseCase()
+                .map { it.getOrNull()?.toInt() }
                 .filterNotNull()
-        ) { unlockedCardPairs, allCardPairsCount, cardPairCost ->
+        ) { unlockedCardPairs, allCardPairsCount, cardPairCost, unlockedCardPairsFromAdsCount ->
             val lockedCardPairsCount = allCardPairsCount - unlockedCardPairs.size
-            Triple(unlockedCardPairs, lockedCardPairsCount, cardPairCost)
+            getCollectionCardPairs(
+                unlockedCardPairs,
+                lockedCardPairsCount,
+                cardPairCost,
+                unlockedCardPairsFromAdsCount,
+                isAdAvailable
+            )
         }
             .distinctUntilChanged()
-            .onEach { (unlockedCardPairs, lockedCardPairsCount, cardPairCost) ->
+            .onEach { collectionCardPairs ->
                 sendState {
                     copy(
-                        collectionCardPairs = getCollectionCardPairs(
-                            unlockedCardPairs,
-                            lockedCardPairsCount,
-                            cardPairCost
-                        ),
+                        collectionCardPairs = collectionCardPairs,
                     )
                 }
             }
@@ -96,11 +151,18 @@ class CollectionViewModel @Inject constructor(
     private fun getCollectionCardPairs(
         unlockedCardPairs: List<CardPairModel>,
         lockedCardPairsCount: Int,
-        cardPairCost: Int
+        cardPairCost: Int,
+        unlockedCardPairsFromAdsCount: Int,
+        isAdAvailable: Boolean
     ): List<CollectionCardPairModel> {
         val unlocked = unlockedCardPairs.map { CollectionCardPairModel.Unlocked(it) }
         val lockedToUnlockWithCoins = getLockedToUnlockWithCoins(lockedCardPairsCount, cardPairCost)
-        val lockedToUnlockWithAd = getLockedToUnlockWithAd(lockedCardPairsCount)
+        val lockedToUnlockWithAd =
+            getLockedToUnlockWithAd(
+                lockedCardPairsCount,
+                unlockedCardPairsFromAdsCount,
+                isAdAvailable
+            )
         val lockedCardPairsNotPossibleToUnlockYet =
             getLockedNotPossibleToUnlockYet(lockedCardPairsCount)
         return unlocked +
@@ -112,9 +174,8 @@ class CollectionViewModel @Inject constructor(
     private fun getLockedToUnlockWithCoins(
         lockedCardPairsCount: Int,
         cardPairCost: Int
-    )
-            : List<CollectionCardPairModel.LockedToUnlockWithCoins> =
-        if (lockedCardPairsCount > 0) {
+    ): List<CollectionCardPairModel.LockedToUnlockWithCoins> =
+        if (lockedCardPairsCount > NO_LOCKED_CARD_PAIRS) {
             List(UNLOCK_WITH_COINS_COUNT) {
                 CollectionCardPairModel.LockedToUnlockWithCoins(cardPairCost)
             }
@@ -122,13 +183,21 @@ class CollectionViewModel @Inject constructor(
             emptyList()
         }
 
-    private fun getLockedToUnlockWithAd(lockedCardPairsCount: Int)
-            : List<CollectionCardPairModel.LockedToUnlockWithAd> =
-        if (lockedCardPairsCount > 1) {
-            List(UNLOCK_WITH_ADS_COUNT) { CollectionCardPairModel.LockedToUnlockWithAd }
+    private fun getLockedToUnlockWithAd(
+        lockedCardPairsCount: Int,
+        unlockedCardPairsFromAdsCount: Int,
+        isAdAvailable: Boolean
+    ): List<CollectionCardPairModel> {
+        return if (lockedCardPairsCount > LAST_LOCKED_CARD_PAIR) {
+            if (unlockedCardPairsFromAdsCount < MAX_UNLOCKED_CARD_PAIRS_WITH_ADS && isAdAvailable) {
+                List(UNLOCK_WITH_ADS_COUNT) { CollectionCardPairModel.LockedToUnlockWithAd }
+            } else {
+                List(UNLOCK_WITH_ADS_COUNT) { CollectionCardPairModel.Locked }
+            }
         } else {
             emptyList()
         }
+    }
 
     private fun getLockedNotPossibleToUnlockYet(lockedCardPairsCount: Int)
             : List<CollectionCardPairModel.Locked> {
@@ -157,14 +226,22 @@ class CollectionViewModel @Inject constructor(
             result.onSuccess {
                 delay(COINS_SOUND_DELAY)
                 coinsPlayer.play()
-                loadData(true)
+                loadData(animateCoins = true)
             }
         }.launchIn(viewModelScope)
     }
 
+    private fun onUnlockWithAdClick() {
+        hapticFeedback.vibrateLow()
+        sendEffect(CollectionEffect.ShowAd(allRewardedAds.endGameCoinsAd))
+    }
+
     companion object {
+        const val NO_LOCKED_CARD_PAIRS = 0
+        const val LAST_LOCKED_CARD_PAIR = 1
         const val UNLOCK_WITH_ADS_COUNT = 1
         const val UNLOCK_WITH_COINS_COUNT = 1
+        const val MAX_UNLOCKED_CARD_PAIRS_WITH_ADS = 3
 
         const val NUMBER_OF_LOCKED_CARDS_POSSIBLE_TO_UNLOCK =
             UNLOCK_WITH_COINS_COUNT + UNLOCK_WITH_ADS_COUNT

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CardPairsCollection.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CardPairsCollection.kt
@@ -151,8 +151,11 @@ private fun BackSide(
                         onClick = { callbacks.onUnlockWithCoinsClick(targetState) }
                     )
 
-                is CollectionCardPairModel.LockedToUnlockWithAd -> CollectionLockedCardPair()
-                is CollectionCardPairModel.Unlocked -> { /* handled in FrontSide */
+                is CollectionCardPairModel.LockedToUnlockWithAd -> CollectionUnlockCardPairWithAd(
+                    onClick = { callbacks.onUnlockWithAdClick(targetState) }
+                )
+                is CollectionCardPairModel.Unlocked -> {
+                    // handled in FrontSide
                 }
             }
         }

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CardPairsCollection.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CardPairsCollection.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,12 +34,30 @@ import com.wojdor.memolki.domain.model.CollectionCardPairModel
 import com.wojdor.memolki.ui.components.Flippable
 import com.wojdor.memolki.ui.feature.collection.CollectionCallbacks
 import com.wojdor.memolki.ui.feature.collection.CollectionState
+import kotlinx.coroutines.delay
 
 @Composable
 fun CardPairsCollection(
     state: CollectionState,
     callbacks: CollectionCallbacks
 ) {
+    var isClickBlocked by remember { mutableStateOf(false) }
+    val groupThrottleCallbacks = remember(callbacks) {
+        callbacks.copy(
+            onUnlockedCardPairClick = {
+                if (!isClickBlocked) {
+                    isClickBlocked = true
+                    callbacks.onUnlockedCardPairClick(it)
+                }
+            }
+        )
+    }
+    LaunchedEffect(isClickBlocked) {
+        if (isClickBlocked) {
+            delay(ON_FRONT_CARDS_CLICK_THROTTLE)
+            isClickBlocked = false
+        }
+    }
     BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
@@ -61,7 +80,7 @@ fun CardPairsCollection(
                     CollectionCardPair(
                         modifier = Modifier.size(cardPairSize),
                         collectionCardPair = collectionCardPair,
-                        callbacks = callbacks
+                        callbacks = groupThrottleCallbacks
                     )
                 }
             }
@@ -198,3 +217,4 @@ private fun FadeEffectBottom(modifier: Modifier) {
 
 private val FADE_EFFECT_HEIGHT = 6.dp
 private const val ALPHA_DURATION = 300
+private const val ON_FRONT_CARDS_CLICK_THROTTLE = 500L

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CardPairsCollection.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CardPairsCollection.kt
@@ -1,6 +1,7 @@
 package com.wojdor.memolki.ui.feature.collection.component
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -27,11 +29,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import com.wojdor.memolki.R
 import com.wojdor.memolki.domain.model.CollectionCardPairModel
-import com.wojdor.memolki.ui.components.Flippable
+import com.wojdor.memolki.ui.component.Flippable
 import com.wojdor.memolki.ui.feature.collection.CollectionCallbacks
 import com.wojdor.memolki.ui.feature.collection.CollectionState
 import kotlinx.coroutines.delay
@@ -68,9 +71,41 @@ fun CardPairsCollection(
         val columns = 2
         val shorterEdge = maxWidth.coerceAtMost(maxHeight)
         val cardPairSize = (shorterEdge - spacing * (columns - 1)) / columns
+        val lazyGridState = rememberLazyGridState()
+        val firstLockedToUnlockWithCoinsIndex = remember(state.collectionCardPairs) {
+            state.collectionCardPairs.indexOfFirst {
+                it is CollectionCardPairModel.LockedToUnlockWithCoins
+            } - columns
+        }
+        val spacingInPixels = with(LocalDensity.current) { spacing.toPx() }
+        val cardPairSizeInPixels = with(LocalDensity.current) { cardPairSize.toPx() }
+        var hasScrolled by remember {
+            mutableStateOf(lazyGridState.firstVisibleItemIndex != 0)
+        }
+
+        LaunchedEffect(firstLockedToUnlockWithCoinsIndex) {
+            if (firstLockedToUnlockWithCoinsIndex > INDEX_NOT_FOUND && !hasScrolled) {
+                hasScrolled = true
+                delay(SCROLL_DELAY)
+                val rowIndex = firstLockedToUnlockWithCoinsIndex / columns
+                val targetOffset = rowIndex * (cardPairSizeInPixels + spacingInPixels)
+                lazyGridState.scroll {
+                    var previousValue = lazyGridState.firstVisibleItemScrollOffset.toFloat()
+                    Animatable(previousValue).animateTo(
+                        targetValue = targetOffset,
+                        animationSpec = tween(durationMillis = SCROLL_DURATION)
+                    ) {
+                        val delta = value - previousValue
+                        scrollBy(delta)
+                        previousValue = value
+                    }
+                }
+            }
+        }
 
         Box(modifier = Modifier.fillMaxSize()) {
             LazyVerticalGrid(
+                state = lazyGridState,
                 columns = GridCells.Fixed(columns),
                 verticalArrangement = Arrangement.spacedBy(spacing),
                 horizontalArrangement = Arrangement.spacedBy(spacing),
@@ -173,6 +208,7 @@ private fun BackSide(
                 is CollectionCardPairModel.LockedToUnlockWithAd -> CollectionUnlockCardPairWithAd(
                     onClick = { callbacks.onUnlockWithAdClick(targetState) }
                 )
+
                 is CollectionCardPairModel.Unlocked -> {
                     // handled in FrontSide
                 }
@@ -218,3 +254,6 @@ private fun FadeEffectBottom(modifier: Modifier) {
 private val FADE_EFFECT_HEIGHT = 6.dp
 private const val ALPHA_DURATION = 300
 private const val ON_FRONT_CARDS_CLICK_THROTTLE = 500L
+private const val INDEX_NOT_FOUND = -1
+private const val SCROLL_DELAY = 500L
+private const val SCROLL_DURATION = 800

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CollectionLockedCard.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CollectionLockedCard.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wojdor.memolki.R
-import com.wojdor.memolki.ui.components.XmlDrawable
+import com.wojdor.memolki.ui.component.XmlDrawable
 import com.wojdor.memolki.ui.feature.game.component.CardBorder
 import com.wojdor.memolki.ui.theme.AppTheme
 

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CollectionLockedCardPair.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CollectionLockedCardPair.kt
@@ -46,6 +46,11 @@ fun CollectionLockedCardPair(modifier: Modifier = Modifier) {
     }
 }
 
+internal const val CARD_SIZE_FRACTION = 0.65f
+internal const val CARD_ROTATION = 10f
+internal val CARD_OFFSET = 24.dp
+private val LOCKED_ICON_SIZE = 48.dp
+
 @Preview
 @Composable
 fun CollectionLockedCardPairPreview() {
@@ -53,8 +58,3 @@ fun CollectionLockedCardPairPreview() {
         CollectionLockedCardPair(Modifier.size(192.dp))
     }
 }
-
-internal const val CARD_SIZE_FRACTION = 0.65f
-internal const val CARD_ROTATION = 10f
-internal val CARD_OFFSET = 24.dp
-private val LOCKED_ICON_SIZE = 48.dp

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CollectionUnlockCardPairWithAd.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CollectionUnlockCardPairWithAd.kt
@@ -2,14 +2,11 @@ package com.wojdor.memolki.ui.feature.collection.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,17 +16,14 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wojdor.memolki.R
-import com.wojdor.memolki.domain.model.CollectionCardPairModel
-import com.wojdor.memolki.ui.components.AutoSizeText
 import com.wojdor.memolki.ui.shape.RotatedCardPairShape
 import com.wojdor.memolki.ui.theme.AppTheme
 import com.wojdor.memolki.ui.theme.CardShape
 import com.wojdor.memolki.util.throttleClick
 
 @Composable
-fun CollectionUnlockCardPairWithCoins(
+fun CollectionUnlockCardPairWithAd(
     modifier: Modifier = Modifier,
-    collectionCardPairModel: CollectionCardPairModel.LockedToUnlockWithCoins,
     onClick: () -> Unit = {}
 ) {
     Box(
@@ -62,42 +56,27 @@ fun CollectionUnlockCardPairWithCoins(
             contentAlignment = Alignment.Center
         ) {
             CollectionLockedCard()
-            UnlockWithCoins(collectionCardPairModel)
+            Image(
+                modifier = Modifier
+                    .padding(8.dp)
+                    .size(ADS_ICON_SIZE),
+                painter = painterResource(R.drawable.ic_ads),
+                contentDescription = null,
+            )
         }
     }
 }
 
-@Composable
-private fun UnlockWithCoins(
-    collectionCardPairModel: CollectionCardPairModel.LockedToUnlockWithCoins
-) {
-    Row(
-        modifier = Modifier.padding(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center
-    ) {
-        Image(
-            modifier = Modifier.size(COIN_ICON_SIZE),
-            painter = painterResource(R.drawable.ic_coin),
-            contentDescription = null,
-        )
-        AutoSizeText(
-            modifier = Modifier.padding(start = 4.dp),
-            text = collectionCardPairModel.coins.toString(),
-            style = MaterialTheme.typography.headlineMedium,
-        )
-    }
-}
+private val ADS_ICON_SIZE = 64.dp
 
-private val COIN_ICON_SIZE = 32.dp
 
 @Preview
 @Composable
-fun CollectionUnlockCardPairWithCoinsPreview() {
+fun CollectionUnlockCardPairWithAdPreview() {
     AppTheme {
-        CollectionUnlockCardPairWithCoins(
+        CollectionUnlockCardPairWithAd(
             modifier = Modifier.size(192.dp),
-            collectionCardPairModel = CollectionCardPairModel.LockedToUnlockWithCoins(coins = 100)
         )
     }
 }
+

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CollectionUnlockCardPairWithCoins.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/collection/component/CollectionUnlockCardPairWithCoins.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wojdor.memolki.R
 import com.wojdor.memolki.domain.model.CollectionCardPairModel
-import com.wojdor.memolki.ui.components.AutoSizeText
+import com.wojdor.memolki.ui.component.AutoSizeText
 import com.wojdor.memolki.ui.shape.RotatedCardPairShape
 import com.wojdor.memolki.ui.theme.AppTheme
 import com.wojdor.memolki.ui.theme.CardShape

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/endgame/EndGameViewModel.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/endgame/EndGameViewModel.kt
@@ -26,7 +26,7 @@ class EndGameViewModel @Inject constructor(
     private val levelCompletePlayer: LevelCompletePlayer,
     private val coinsPlayer: CoinsPlayer,
     private val hapticFeedback: HapticFeedback,
-    private val rewardedAds: AllRewardedAds,
+    private val allRewardedAds: AllRewardedAds,
     private val incrementTotalGamesPlayedUseCase: IncrementTotalGamesPlayedUseCase,
     private val getCoinsUseCase: GetCoinsUseCase,
     private val rewardCoinsForLevelUseCase: RewardCoinsForLevelUseCase
@@ -52,14 +52,14 @@ class EndGameViewModel @Inject constructor(
         incrementTotalGamesPlayedUseCase().launchIn(viewModelScope)
         getCurrentCoinsAndReward(level)
         viewModelScope.launch {
-            delay(250)
+            delay(LEVEL_COMPLETE_SOUND_DELAY)
             levelCompletePlayer.play()
         }
     }
 
     private fun onAdReward() {
         showMenu(false)
-        rewardedAds.endGameCoinsAd.load()
+        allRewardedAds.endGameCoinsAd.load()
     }
 
     private fun onAdDismiss(wasRewardGranted: Boolean) {
@@ -74,11 +74,11 @@ class EndGameViewModel @Inject constructor(
     }
 
     private fun loadAd(wasRewardGranted: Boolean = false) {
-        if (rewardedAds.endGameCoinsAd.isLoaded && !wasRewardGranted) {
+        if (allRewardedAds.endGameCoinsAd.isLoaded && !wasRewardGranted) {
             showMenu(true)
         } else {
             showMenu(false)
-            rewardedAds.endGameCoinsAd.load(
+            allRewardedAds.endGameCoinsAd.load(
                 onLoaded = {
                     if (!wasRewardGranted) {
                         showMenu(true)
@@ -101,7 +101,7 @@ class EndGameViewModel @Inject constructor(
 
     private fun onWatchAdClick() {
         hapticFeedback.vibrateLow()
-        sendEffect(EndGameEffect.ShowAd(rewardedAds.endGameCoinsAd))
+        sendEffect(EndGameEffect.ShowAd(allRewardedAds.endGameCoinsAd))
     }
 
     private fun showMenu(isAdLoaded: Boolean) {
@@ -150,6 +150,7 @@ class EndGameViewModel @Inject constructor(
     )
 
     companion object {
+        const val LEVEL_COMPLETE_SOUND_DELAY = 250L
         const val COINS_SOUND_DELAY = 500L
     }
 }

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/endgame/EndGameViewModel.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/endgame/EndGameViewModel.kt
@@ -59,7 +59,6 @@ class EndGameViewModel @Inject constructor(
 
     private fun onAdReward() {
         showMenu(false)
-        allRewardedAds.endGameCoinsAd.load()
     }
 
     private fun onAdDismiss(wasRewardGranted: Boolean) {

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/endgame/component/EndGameContent.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/endgame/component/EndGameContent.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wojdor.memolki.domain.model.EndGameMenuModel
 import com.wojdor.memolki.domain.model.LevelModel
-import com.wojdor.memolki.ui.components.CoinsAmount
+import com.wojdor.memolki.ui.component.CoinsAmount
 import com.wojdor.memolki.ui.feature.endgame.EndGameCallbacks
 import com.wojdor.memolki.ui.feature.endgame.EndGameState
 import com.wojdor.memolki.ui.feature.menu.component.MenuItem

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/game/component/BackCardItem.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/game/component/BackCardItem.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wojdor.memolki.R
-import com.wojdor.memolki.ui.components.XmlDrawable
+import com.wojdor.memolki.ui.component.XmlDrawable
 import com.wojdor.memolki.ui.theme.CardShape
 import com.wojdor.memolki.util.throttleClick
 

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/game/component/CardsGrid.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/game/component/CardsGrid.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.dp
 import com.wojdor.memolki.R
 import com.wojdor.memolki.domain.model.CardModel
 import com.wojdor.memolki.domain.model.LevelModel
-import com.wojdor.memolki.ui.components.AutoSizeText
+import com.wojdor.memolki.ui.component.AutoSizeText
 import com.wojdor.memolki.ui.feature.game.GameCallbacks
 import com.wojdor.memolki.ui.feature.game.GameState
 import com.wojdor.memolki.ui.theme.AppTheme

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/game/component/FlippableCardItem.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/game/component/FlippableCardItem.kt
@@ -3,7 +3,7 @@ package com.wojdor.memolki.ui.feature.game.component
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.wojdor.memolki.domain.model.CardModel
-import com.wojdor.memolki.ui.components.Flippable
+import com.wojdor.memolki.ui.component.Flippable
 import com.wojdor.memolki.ui.feature.game.GameCallbacks
 
 @Composable

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/game/component/FrontCardItem.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/game/component/FrontCardItem.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wojdor.memolki.R
 import com.wojdor.memolki.domain.model.CardModel
-import com.wojdor.memolki.ui.components.AutoSizeText
+import com.wojdor.memolki.ui.component.AutoSizeText
 import com.wojdor.memolki.ui.theme.AppTheme
 import com.wojdor.memolki.ui.theme.CardShape
 

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/menu/component/MenuItem.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/menu/component/MenuItem.kt
@@ -4,7 +4,7 @@ import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.wojdor.memolki.R
-import com.wojdor.memolki.ui.components.BaseMenuItem
+import com.wojdor.memolki.ui.component.BaseMenuItem
 import com.wojdor.memolki.ui.theme.AppTheme
 
 @Composable

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopCallbacks.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopCallbacks.kt
@@ -1,3 +1,5 @@
 package com.wojdor.memolki.ui.feature.shop
 
-class ShopCallbacks
+data class ShopCallbacks(
+    val onRewardCoinsWithAdClick: () -> Unit = {},
+)

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopEffect.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopEffect.kt
@@ -1,5 +1,8 @@
 package com.wojdor.memolki.ui.feature.shop
 
+import com.wojdor.memolki.ui.ads.RewardedAd
 import com.wojdor.memolki.ui.base.UiEffect
 
-sealed class ShopEffect : UiEffect
+sealed class ShopEffect : UiEffect {
+    data class ShowAd(val rewardedAd: RewardedAd) : ShopEffect()
+}

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopIntent.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopIntent.kt
@@ -2,4 +2,12 @@ package com.wojdor.memolki.ui.feature.shop
 
 import com.wojdor.memolki.ui.base.UiIntent
 
-sealed class ShopIntent : UiIntent
+sealed class ShopIntent : UiIntent {
+
+    object OnRewardCoinsWithAdClick : ShopIntent()
+
+    object OnAdReward : ShopIntent()
+
+    data class OnAdDismiss(val wasRewardGranted: Boolean) : ShopIntent()
+}
+

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopScreen.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopScreen.kt
@@ -1,19 +1,17 @@
 package com.wojdor.memolki.ui.feature.shop
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
+import android.app.Activity
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
-import com.wojdor.memolki.R
+import com.wojdor.memolki.ui.ads.RewardedAd
 import com.wojdor.memolki.ui.base.CollectUiEffects
+import com.wojdor.memolki.ui.feature.collection.CollectionEffect
+import com.wojdor.memolki.ui.feature.shop.component.ShopContent
 import com.wojdor.memolki.ui.theme.AppTheme
 
 @Composable
@@ -31,11 +29,24 @@ private fun HandleEffect(
     viewModel: ShopViewModel,
     navController: NavController
 ) {
-    CollectUiEffects(viewModel) {
-        when (it) {
-            else -> TODO()
+    val activity = LocalActivity.current
+    CollectUiEffects(viewModel) { effect ->
+        when (effect) {
+            is CollectionEffect.ShowAd -> activity?.let { showAd(it, viewModel, effect.rewardedAd) }
         }
     }
+}
+
+private fun showAd(
+    activity: Activity,
+    viewModel: ShopViewModel,
+    rewardedAd: RewardedAd
+) {
+    rewardedAd.show(
+        activity,
+        onGrantReward = { viewModel.sendIntent(ShopIntent.OnAdReward) },
+        onAdDismiss = { viewModel.sendIntent(ShopIntent.OnAdDismiss(it)) }
+    )
 }
 
 @Composable
@@ -43,7 +54,9 @@ private fun HandleState(
     viewModel: ShopViewModel,
     state: ShopState
 ) {
-    val callbacks = ShopCallbacks()
+    val callbacks = ShopCallbacks(
+        onRewardCoinsWithAdClick = { viewModel.sendIntent(ShopIntent.OnRewardCoinsWithAdClick) }
+    )
     ShopScreen(state, callbacks)
 }
 
@@ -52,12 +65,7 @@ private fun ShopScreen(
     state: ShopState,
     callbacks: ShopCallbacks = ShopCallbacks()
 ) {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(stringResource(R.string.shop))
-    }
+    ShopContent(state, callbacks)
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopState.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopState.kt
@@ -4,4 +4,7 @@ import com.wojdor.memolki.ui.base.UiState
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class ShopState : UiState
+data class ShopState(
+    val coins: Long = 0L,
+    val animateCoins: Boolean = true
+) : UiState

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopViewModel.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopViewModel.kt
@@ -1,21 +1,106 @@
 package com.wojdor.memolki.ui.feature.shop
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.wojdor.memolki.domain.usecase.GetCoinsUseCase
+import com.wojdor.memolki.domain.usecase.RewardCoinsForShopAdUseCase
+import com.wojdor.memolki.ui.ads.AllRewardedAds
 import com.wojdor.memolki.ui.base.MviViewModel
+import com.wojdor.memolki.util.media.CoinsPlayer
+import com.wojdor.memolki.util.media.HapticFeedback
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @HiltViewModel
 class ShopViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val hapticFeedback: HapticFeedback,
+    private val coinsPlayer: CoinsPlayer,
+    private val allRewardedAds: AllRewardedAds,
+    private val getCoinsUseCase: GetCoinsUseCase,
+    private val rewardCoinsForShopAdUseCase: RewardCoinsForShopAdUseCase
 ) : MviViewModel<ShopIntent, ShopState>(
     savedStateHandle,
     ShopState()
 ) {
 
+    init {
+        loadData()
+    }
+
     override fun onIntent(intent: ShopIntent) {
         when (intent) {
-            else -> TODO()
+            ShopIntent.OnRewardCoinsWithAdClick -> onUnlockWithAdClick()
+            ShopIntent.OnAdReward -> onAdReward()
+            is ShopIntent.OnAdDismiss -> onAdDismiss(intent.wasRewardGranted)
         }
     }
+
+    private fun loadData(animateCoins: Boolean = false) {
+        loadMenuItemsAndAd()
+        loadCoins(animateCoins)
+    }
+
+    private fun onUnlockWithAdClick() {
+        hapticFeedback.vibrateLow()
+        sendEffect(ShopEffect.ShowAd(allRewardedAds.shopCoinsAd))
+    }
+
+    private fun onAdReward() {
+        loadMenu(isAdAvailable = false)
+        allRewardedAds.shopCoinsAd.load()
+    }
+
+    private fun onAdDismiss(wasRewardGranted: Boolean) {
+        if (wasRewardGranted) {
+            rewardCoinsForAd()
+        }
+        loadMenuItemsAndAd(wasRewardGranted)
+    }
+
+    private fun rewardCoinsForAd() {
+        rewardCoinsForShopAdUseCase().onEach { result ->
+            result.onSuccess {
+                delay(COINS_SOUND_DELAY)
+                coinsPlayer.play()
+                loadData(animateCoins = true)
+            }
+        }.launchIn(viewModelScope)
+    }
+
+    private fun loadMenuItemsAndAd(wasRewardGranted: Boolean = false) {
+        if (allRewardedAds.collectionCardPairAd.isLoaded && !wasRewardGranted) {
+            loadMenu(isAdAvailable = true)
+        } else {
+            loadMenu(isAdAvailable = false)
+            allRewardedAds.collectionCardPairAd.load(
+                onLoaded = {
+                    if (!wasRewardGranted) {
+                        loadMenu(isAdAvailable = true)
+                    }
+                },
+                onFailed = {
+                    loadMenu(isAdAvailable = false)
+                }
+            )
+        }
+    }
+
+    private fun loadMenu(isAdAvailable: Boolean) {
+        // TODO: reload menu items
+    }
+
+    private fun loadCoins(animateCoins: Boolean) {
+        getCoinsUseCase().onEach {
+            it.onSuccess { coins ->
+                sendState { copy(coins = coins, animateCoins = animateCoins) }
+            }
+        }.launchIn(viewModelScope)
+    }
+
 }
+
+private const val COINS_SOUND_DELAY = 300L

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopViewModel.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopViewModel.kt
@@ -72,11 +72,11 @@ class ShopViewModel @Inject constructor(
     }
 
     private fun loadMenuItemsAndAd(wasRewardGranted: Boolean = false) {
-        if (allRewardedAds.collectionCardPairAd.isLoaded && !wasRewardGranted) {
+        if (allRewardedAds.shopCoinsAd.isLoaded && !wasRewardGranted) {
             loadMenu(isAdAvailable = true)
         } else {
             loadMenu(isAdAvailable = false)
-            allRewardedAds.collectionCardPairAd.load(
+            allRewardedAds.shopCoinsAd.load(
                 onLoaded = {
                     if (!wasRewardGranted) {
                         loadMenu(isAdAvailable = true)

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopViewModel.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/shop/ShopViewModel.kt
@@ -51,7 +51,6 @@ class ShopViewModel @Inject constructor(
 
     private fun onAdReward() {
         loadMenu(isAdAvailable = false)
-        allRewardedAds.shopCoinsAd.load()
     }
 
     private fun onAdDismiss(wasRewardGranted: Boolean) {

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/shop/component/ShopContent.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/shop/component/ShopContent.kt
@@ -1,24 +1,27 @@
-package com.wojdor.memolki.ui.feature.collection.component
+package com.wojdor.memolki.ui.feature.shop.component
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.wojdor.memolki.R
 import com.wojdor.memolki.ui.component.CoinsAmount
-import com.wojdor.memolki.ui.feature.collection.CollectionCallbacks
-import com.wojdor.memolki.ui.feature.collection.CollectionState
-import com.wojdor.memolki.ui.feature.collection.getCollectionStateForPreview
+import com.wojdor.memolki.ui.feature.shop.ShopCallbacks
+import com.wojdor.memolki.ui.feature.shop.ShopState
 import com.wojdor.memolki.ui.theme.AppTheme
 
 @Composable
-fun CollectionContent(
-    state: CollectionState,
-    callbacks: CollectionCallbacks = CollectionCallbacks()
+fun ShopContent(
+    state: ShopState,
+    callbacks: ShopCallbacks = ShopCallbacks()
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         Row(
@@ -30,15 +33,13 @@ fun CollectionContent(
                 coins = state.coins,
                 animate = state.animateCoins
             )
-            ShopButton(
-                onClick = callbacks.onShopButtonClick
-            )
         }
-        UnlockedCardPairsCounter(
-            modifier = Modifier.padding(bottom = 8.dp),
-            state = state
-        )
-        CardPairsCollection(state, callbacks)
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(stringResource(R.string.shop))
+        }
     }
 }
 
@@ -46,8 +47,8 @@ fun CollectionContent(
 @Preview(showBackground = true)
 private fun CollectionPreview() {
     AppTheme {
-        CollectionContent(
-            state = getCollectionStateForPreview()
+        ShopContent(
+            state = ShopState(1234)
         )
     }
 }

--- a/app/src/main/java/com/wojdor/memolki/ui/feature/shop/component/ShopContent.kt
+++ b/app/src/main/java/com/wojdor/memolki/ui/feature/shop/component/ShopContent.kt
@@ -45,7 +45,7 @@ fun ShopContent(
 
 @Composable
 @Preview(showBackground = true)
-private fun CollectionPreview() {
+private fun ShopContentPreview() {
     AppTheme {
         ShopContent(
             state = ShopState(1234)

--- a/app/src/main/java/com/wojdor/memolki/util/media/BackgroundMusicPlayer.kt
+++ b/app/src/main/java/com/wojdor/memolki/util/media/BackgroundMusicPlayer.kt
@@ -47,17 +47,17 @@ class BackgroundMusicPlayer @Inject constructor(
                 result.onSuccess { settings ->
                     isMusicEnabled =
                         settings.filterIsInstance<SettingModel.Music>().first().isEnabled
-                    onStart()
+                    playIfMusicEnabled()
                 }
             }
         }
     }
 
-    override fun onStart(owner: LifecycleOwner) {
-        onStart()
+    override fun onResume(owner: LifecycleOwner) {
+        playIfMusicEnabled()
     }
 
-    override fun onStop(owner: LifecycleOwner) {
+    override fun onPause(owner: LifecycleOwner) {
         pause()
     }
 
@@ -99,7 +99,7 @@ class BackgroundMusicPlayer @Inject constructor(
         }
     }
 
-    private fun onStart() {
+    private fun playIfMusicEnabled() {
         if (isMusicEnabled) {
             start()
         } else {

--- a/app/src/main/java/com/wojdor/memolki/util/media/HapticFeedback.kt
+++ b/app/src/main/java/com/wojdor/memolki/util/media/HapticFeedback.kt
@@ -82,9 +82,9 @@ open class HapticFeedback @Inject constructor(
     }
 
     companion object {
-        private const val VIBRATE_LOW_MS = 10L
-        private const val VIBRATE_LOW_AMPLITUDE = 25
+        private const val VIBRATE_LOW_MS = 20L
+        private const val VIBRATE_LOW_AMPLITUDE = 50
         private const val VIBRATE_STRONG_MS = 30L
-        private const val VIBRATE_STRONG_AMPLITUDE = 50
+        private const val VIBRATE_STRONG_AMPLITUDE = 200
     }
 }

--- a/app/src/test/java/com/wojdor/memolki/data/repository/UserRepositoryTest.kt
+++ b/app/src/test/java/com/wojdor/memolki/data/repository/UserRepositoryTest.kt
@@ -144,4 +144,37 @@ class UserRepositoryTest : AppTest() {
         val expected = initialCount + 1
         assertEquals(expected, result)
     }
+
+    @Test
+    fun `when getUnlockedCardPairsFromAdsCount then should return decrypted value`() = runTest {
+        // given
+        val expected = 5L
+        userLocalDataSource.setEncryptedUnlockedCardPairsFromAdsCount {
+            mockEncryptor.encrypt(expected)
+        }
+
+        // when
+        val result = sut.getUnlockedCardPairsFromAdsCount().first()
+
+        // then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `when incrementUnlockedCardPairsFromAdsCount then should increment value in data source`() =
+        runTest {
+            // given
+            val initialCount = 5L
+            userLocalDataSource.setEncryptedUnlockedCardPairsFromAdsCount {
+                mockEncryptor.encrypt(initialCount)
+            }
+
+            // when
+            sut.incrementUnlockedCardPairsFromAdsCount()
+
+            // then
+            val result = sut.getUnlockedCardPairsFromAdsCount().first()
+            val expected = initialCount + 1
+            assertEquals(expected, result)
+        }
 }

--- a/app/src/test/java/com/wojdor/memolki/domain/usecase/GetUnlockedCardPairsFromAdsCountUseCaseTest.kt
+++ b/app/src/test/java/com/wojdor/memolki/domain/usecase/GetUnlockedCardPairsFromAdsCountUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.wojdor.memolki.domain.usecase
+
+import com.wojdor.memolki.data.local.user.UserLocalDataSource
+import com.wojdor.memolki.data.repository.UserRepository
+import com.wojdor.memolki.test.AppTest
+import com.wojdor.memolki.test.mock.MockDataStore
+import com.wojdor.memolki.test.mock.MockEncryptor
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class GetUnlockedCardPairsFromAdsCountUseCaseTest : AppTest() {
+
+    private lateinit var userRepository: UserRepository
+    private lateinit var sut: GetUnlockedCardPairsFromAdsCountUseCase
+
+    @Before
+    override fun setup() {
+        super.setup()
+        userRepository = UserRepository(
+            MockEncryptor(),
+            UserLocalDataSource(MockDataStore())
+        )
+        sut = GetUnlockedCardPairsFromAdsCountUseCase(
+            testDispatcher,
+            userRepository
+        )
+    }
+
+    @Test
+    fun `when use case is executed then should return unlocked card pairs from ads count`() =
+        runTest {
+            // given
+            userRepository.incrementUnlockedCardPairsFromAdsCount()
+            userRepository.incrementUnlockedCardPairsFromAdsCount()
+
+            // when
+            val result = sut().first()
+
+            // then
+            assertEquals(Result.success(2L), result)
+        }
+}

--- a/app/src/test/java/com/wojdor/memolki/domain/usecase/IncrementUnlockedCardPairsFromAdsCountUseCaseTest.kt
+++ b/app/src/test/java/com/wojdor/memolki/domain/usecase/IncrementUnlockedCardPairsFromAdsCountUseCaseTest.kt
@@ -1,0 +1,43 @@
+package com.wojdor.memolki.domain.usecase
+
+import com.wojdor.memolki.data.local.user.UserLocalDataSource
+import com.wojdor.memolki.data.repository.UserRepository
+import com.wojdor.memolki.test.AppTest
+import com.wojdor.memolki.test.mock.MockDataStore
+import com.wojdor.memolki.test.mock.MockEncryptor
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class IncrementUnlockedCardPairsFromAdsCountUseCaseTest : AppTest() {
+
+    private lateinit var userRepository: UserRepository
+    private lateinit var sut: IncrementUnlockedCardPairsFromAdsCountUseCase
+
+    @Before
+    override fun setup() {
+        super.setup()
+        userRepository = UserRepository(
+            MockEncryptor(),
+            UserLocalDataSource(MockDataStore())
+        )
+        sut = IncrementUnlockedCardPairsFromAdsCountUseCase(
+            testDispatcher,
+            userRepository
+        )
+    }
+
+    @Test
+    fun `when use case is executed then should increment unlocked card pairs from ads count`() =
+        runTest {
+            // when
+            sut().first()
+
+            // then
+            assertEquals(1, userRepository.getUnlockedCardPairsFromAdsCount().first())
+        }
+}

--- a/app/src/test/java/com/wojdor/memolki/domain/usecase/RewardCoinsForShopAdUseCaseTest.kt
+++ b/app/src/test/java/com/wojdor/memolki/domain/usecase/RewardCoinsForShopAdUseCaseTest.kt
@@ -1,0 +1,62 @@
+package com.wojdor.memolki.domain.usecase
+
+import app.cash.turbine.test
+import com.wojdor.memolki.data.local.card.UnlockedCardPairsLocalDataSource
+import com.wojdor.memolki.data.local.user.UserLocalDataSource
+import com.wojdor.memolki.data.repository.CardRepository
+import com.wojdor.memolki.data.repository.UserRepository
+import com.wojdor.memolki.test.AppTest
+import com.wojdor.memolki.test.mock.MockAllCardPairsDataSource
+import com.wojdor.memolki.test.mock.MockDataStore
+import com.wojdor.memolki.test.mock.MockEncryptor
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class RewardCoinsForShopAdUseCaseTest : AppTest() {
+
+    private lateinit var userRepository: UserRepository
+    private lateinit var sut: RewardCoinsForShopAdUseCase
+
+    @Before
+    override fun setup() {
+        super.setup()
+        userRepository = UserRepository(
+            MockEncryptor(), UserLocalDataSource(
+                MockDataStore()
+            )
+        )
+        sut = RewardCoinsForShopAdUseCase(
+            testDispatcher,
+            userRepository,
+            GetLevelsUseCase(
+                testDispatcher, GetUnlockedCardPairsCountUseCase(
+                    testDispatcher,
+                    CardRepository(
+                        MockAllCardPairsDataSource, UnlockedCardPairsLocalDataSource(
+                            MockDataStore(),
+                            MockAllCardPairsDataSource
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `given unlocked levels when execute then should reward coins based on the biggest unlocked level`() =
+        runTest {
+            // when
+            sut().test {
+                assertEquals(Result.success(Unit), awaitItem())
+                awaitComplete()
+
+                // then
+                assertEquals(6, userRepository.getCoins().first())
+            }
+        }
+}

--- a/app/src/test/java/com/wojdor/memolki/domain/usecase/UnlockRandomCardIfEnoughCoinsUseCaseTest.kt
+++ b/app/src/test/java/com/wojdor/memolki/domain/usecase/UnlockRandomCardIfEnoughCoinsUseCaseTest.kt
@@ -10,13 +10,11 @@ import com.wojdor.memolki.test.mock.MockAllCardPairsDataSource
 import com.wojdor.memolki.test.mock.MockDataStore
 import com.wojdor.memolki.test.mock.MockEncryptor
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.util.NoSuchElementException
 
 @ExperimentalCoroutinesApi
 class UnlockRandomCardIfEnoughCoinsUseCaseTest : AppTest() {
@@ -32,7 +30,8 @@ class UnlockRandomCardIfEnoughCoinsUseCaseTest : AppTest() {
         val dataStore = MockDataStore()
         unlockedCardPairsLocalDataSource =
             UnlockedCardPairsLocalDataSource(dataStore, MockAllCardPairsDataSource)
-        cardRepository = CardRepository(MockAllCardPairsDataSource, unlockedCardPairsLocalDataSource)
+        cardRepository =
+            CardRepository(MockAllCardPairsDataSource, unlockedCardPairsLocalDataSource)
         userRepository = UserRepository(MockEncryptor(), UserLocalDataSource(dataStore))
         val getUnlockedCardPairsCountUseCase =
             GetUnlockedCardPairsCountUseCase(testDispatcher, cardRepository)
@@ -45,7 +44,7 @@ class UnlockRandomCardIfEnoughCoinsUseCaseTest : AppTest() {
         sut = UnlockRandomCardIfEnoughCoinsUseCase(
             testDispatcher,
             calculateNextCardPairCostUseCase,
-            cardRepository,
+            UnlockRandomCardUseCase(testDispatcher, cardRepository),
             userRepository
         )
     }
@@ -86,19 +85,20 @@ class UnlockRandomCardIfEnoughCoinsUseCaseTest : AppTest() {
     }
 
     @Test
-    fun `when user has more than enough coins then should remove correct amount of coins`() = runTest {
-        // given
-        val extraCoins = 100L
-        val nextCardCost = calculateNextCardPairCostUseCase().first().getOrThrow()
-        userRepository.addCoins(nextCardCost + extraCoins)
+    fun `when user has more than enough coins then should remove correct amount of coins`() =
+        runTest {
+            // given
+            val extraCoins = 100L
+            val nextCardCost = calculateNextCardPairCostUseCase().first().getOrThrow()
+            userRepository.addCoins(nextCardCost + extraCoins)
 
-        // when
-        sut().test {
-            awaitItem()
-            awaitComplete()
+            // when
+            sut().test {
+                awaitItem()
+                awaitComplete()
+            }
+
+            // then
+            assertEquals(extraCoins, userRepository.getCoins().first())
         }
-
-        // then
-        assertEquals(extraCoins, userRepository.getCoins().first())
-    }
 }

--- a/app/src/test/java/com/wojdor/memolki/ui/feature/collection/CollectionViewModelTest.kt
+++ b/app/src/test/java/com/wojdor/memolki/ui/feature/collection/CollectionViewModelTest.kt
@@ -12,8 +12,11 @@ import com.wojdor.memolki.domain.usecase.GetAllCardPairsCountUseCase
 import com.wojdor.memolki.domain.usecase.GetCoinsUseCase
 import com.wojdor.memolki.domain.usecase.GetLevelsUseCase
 import com.wojdor.memolki.domain.usecase.GetUnlockedCardPairsCountUseCase
+import com.wojdor.memolki.domain.usecase.GetUnlockedCardPairsFromAdsCountUseCase
 import com.wojdor.memolki.domain.usecase.GetUnlockedCardPairsUseCase
+import com.wojdor.memolki.domain.usecase.IncrementUnlockedCardPairsFromAdsCountUseCase
 import com.wojdor.memolki.domain.usecase.UnlockRandomCardIfEnoughCoinsUseCase
+import com.wojdor.memolki.domain.usecase.UnlockRandomCardUseCase
 import com.wojdor.memolki.test.AppTest
 import com.wojdor.memolki.test.mock.MockAllCardPairsDataSource
 import com.wojdor.memolki.test.mock.MockDataStore
@@ -55,6 +58,8 @@ class CollectionViewModelTest : AppTest() {
         sut = CollectionViewModel(
             savedStateHandle = savedStateHandle,
             hapticFeedback = relaxedMockk(),
+            coinsPlayer = relaxedMockk(),
+            allRewardedAds = relaxedMockk(),
             getCoinsUseCase = GetCoinsUseCase(testDispatcher, userRepository),
             getUnlockedCardPairs = GetUnlockedCardPairsUseCase(
                 testDispatcher,
@@ -68,10 +73,21 @@ class CollectionViewModelTest : AppTest() {
             unlockRandomCardIfEnoughCoinsUseCase = UnlockRandomCardIfEnoughCoinsUseCase(
                 testDispatcher,
                 calculateNextCardPairCostUseCase,
-                cardRepository,
+                UnlockRandomCardUseCase(testDispatcher, cardRepository),
                 userRepository
             ),
-            coinsPlayer = relaxedMockk(),
+            getUnlockedCardPairsFromAdsCountUseCase = GetUnlockedCardPairsFromAdsCountUseCase(
+                testDispatcher,
+                userRepository
+            ),
+            incrementUnlockedCardPairsFromAdsCountUseCase = IncrementUnlockedCardPairsFromAdsCountUseCase(
+                testDispatcher,
+                userRepository
+            ),
+            unlockRandomCardUseCase = UnlockRandomCardUseCase(
+                testDispatcher,
+                cardRepository
+            )
         )
     }
 

--- a/app/src/test/java/com/wojdor/memolki/ui/feature/endgame/EndGameViewModelTest.kt
+++ b/app/src/test/java/com/wojdor/memolki/ui/feature/endgame/EndGameViewModelTest.kt
@@ -18,7 +18,6 @@ import com.wojdor.memolki.util.media.HapticFeedback
 import io.mockk.every
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -43,7 +42,7 @@ class EndGameViewModelTest : AppTest() {
             hapticFeedback = hapticFeedback,
             levelCompletePlayer = relaxedMockk(),
             coinsPlayer = relaxedMockk(),
-            rewardedAds = rewardedAds,
+            allRewardedAds = rewardedAds,
             incrementTotalGamesPlayedUseCase = IncrementTotalGamesPlayedUseCase(
                 testDispatcher,
                 userRepository

--- a/app/src/treeLeaf/res/values/ad_mob_ids.xml
+++ b/app/src/treeLeaf/res/values/ad_mob_ids.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="ad_mob_app_id" translatable="false">ca-app-pub-9615601536080764~1304926195</string>
+    <string name="ad_mob_collection_card_pair" translatable="false">ca-app-pub-9615601536080764/6196028904</string>
+    <string name="ad_mob_end_game_coins" translatable="false">ca-app-pub-9615601536080764/2186284093</string>
+    <string name="ad_mob_shop_coins" translatable="false">ca-app-pub-9615601536080764/9929042746</string>
+</resources>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unlock random card pairs by watching rewarded ads in Collection; earn coins by watching ads in Shop.
  - New "unlock with ad" card UI and in-app rewarded-ad display flows.

- **Improvements**
  - Tracks/persists ad-based unlock counts and refreshes Collection after ad rewards.
  - Throttled card taps, auto-scroll to locked items, ad-aware loading.
  - Music lifecycle, stronger haptic feedback, and refined level-complete timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->